### PR TITLE
Fix: Align home page search with properties page search

### DIFF
--- a/rentals/tests/test_views.py
+++ b/rentals/tests/test_views.py
@@ -25,3 +25,82 @@ def test_property_list_view(client):
     response = client.get(url)
     assert response.status_code == 200
     assert b'P1' in response.content
+
+
+from django.test import TestCase
+# Property is already imported from rentals.models
+# reverse is already imported from django.urls
+# timezone is already imported from django.utils
+
+class HomeViewTests(TestCase):
+    def setUp(self):
+        # Get current date for availability
+        today = timezone.now().date()
+
+        self.prop1 = Property.objects.create(
+            title='Property Alpha in Test Location 1',
+            description='Description for Alpha',
+            location='Test Location 1',
+            price_nightly=150.00,
+            price_monthly=3000.00,
+            rental_type=Property.SHORT,
+            bedrooms=3,
+            bathrooms=2,
+            guests=6,
+            sqft=1200,
+            available_from=today,
+            available_to=today + timezone.timedelta(days=30),
+            main_image='alpha.jpg'
+        )
+        self.prop2 = Property.objects.create(
+            title='Property Beta in Another Place',
+            description='Description for Beta',
+            location='Another Place',
+            price_nightly=200.00,
+            price_monthly=4000.00,
+            rental_type=Property.LONG,
+            bedrooms=4,
+            bathrooms=3,
+            guests=8,
+            sqft=2000,
+            available_from=today,
+            available_to=today + timezone.timedelta(days=60),
+            main_image='beta.jpg'
+        )
+
+    def test_home_search_redirects_and_filters(self):
+        """
+        Test that searching from the home page (luxury_home) redirects
+        to the property_list page with filters applied, and that the
+        results on the property_list page are correctly filtered.
+        """
+        search_url = reverse('rentals:luxury_home')
+        query_params = {'location__icontains': 'Test Location 1'}
+
+        # Make the GET request to luxury_home, following redirects
+        response = self.client.get(search_url, query_params, follow=True)
+
+        # Check that the final URL is the property_list page
+        # The redirect chain will be a list of (URL, status_code) tuples
+        self.assertEqual(len(response.redirect_chain), 1)
+        redirect_url, status_code = response.redirect_chain[0]
+
+        # Construct expected redirect URL part (without query string for this check,
+        # as query string format can be tricky with urlencode)
+        expected_list_url_base = reverse('rentals:property_list')
+        self.assertTrue(redirect_url.startswith(expected_list_url_base))
+        self.assertEqual(status_code, 302) # Status of the redirect itself
+
+        # Check the final page after following the redirect
+        self.assertEqual(response.status_code, 200)
+
+        # Check that the correct property is present and the other is not
+        self.assertContains(response, self.prop1.title)
+        self.assertNotContains(response, self.prop2.title)
+
+        # Also check for location to be more specific if titles are similar
+        self.assertContains(response, self.prop1.location)
+        self.assertNotContains(response, self.prop2.location)
+
+        # Verify the query parameters were passed correctly by checking the URL in the redirect chain
+        self.assertIn('location__icontains=Test+Location+1', redirect_url)

--- a/templates/luxury_home.html
+++ b/templates/luxury_home.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {% load static %}
+{% load crispy_forms_tags %}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -33,96 +34,10 @@
             <div class="hero__content">
                 <h1 class="hero__title">Exclusive Properties in Prestigious Locations</h1>
                 <p class="hero__subtitle">Discover luxury accommodations for every occasion</p>
-                <!-- Search Tabs -->
-                <div class="search-tabs">
-                    <button class="search-tab active" data-tab="short-term">Short-term Stays</button>
-                    <button class="search-tab" data-tab="long-term">Long-term Rentals</button>
-                </div>
-                <!-- Short-term Search -->
-                <div id="short-term-search" class="search-container active">
-                    <div class="search-bar">
-                        <div class="search-field">
-                            <label class="search-label">Location</label>
-                            <select id="location-short" class="search-input"></select>
-                        </div>
-                        <div class="search-field">
-                            <label class="search-label">Check-in</label>
-                            <input type="date" id="checkin" class="search-input">
-                        </div>
-                        <div class="search-field">
-                            <label class="search-label">Check-out</label>
-                            <input type="date" id="checkout" class="search-input">
-                        </div>
-                        <div class="search-field guest-field">
-                            <label class="search-label">Guests</label>
-                            <input type="text" id="guests-display" class="search-input" readonly placeholder="Add guests">
-                            <input type="hidden" id="guests" value="1">
-                            <div class="guest-menu">
-                                <div class="guest-row">
-                                    <span class="guest-type">Adults</span>
-                                    <div class="guest-controls">
-                                        <button type="button" class="guest-minus" data-type="adults">-</button>
-                                        <span id="adults-count">1</span>
-                                        <button type="button" class="guest-plus" data-type="adults">+</button>
-                                    </div>
-                                </div>
-                                <div class="guest-row">
-                                    <span class="guest-type">Children</span>
-                                    <div class="guest-controls">
-                                        <button type="button" class="guest-minus" data-type="children">-</button>
-                                        <span id="children-count">0</span>
-                                        <button type="button" class="guest-plus" data-type="children">+</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <button class="search-btn">Search</button>
-                    </div>
-                    <div class="quick-filters">
-                        <button class="filter-pill active" data-filter="all">All Types</button>
-                        <button class="filter-pill" data-filter="entire">Entire Place</button>
-                        <button class="filter-pill" data-filter="private">Private Room</button>
-                        <button class="filter-pill" data-filter="shared">Shared Room</button>
-                    </div>
-                </div>
-                <!-- Long-term Search -->
-                <div id="long-term-search" class="search-container">
-                    <div class="search-bar">
-                        <div class="search-field">
-                            <label class="search-label">Location</label>
-                            <select id="location-long" class="search-input"></select>
-                        </div>
-                        <div class="search-field">
-                            <label class="search-label">Move-in Date</label>
-                            <input type="date" id="movein" class="search-input">
-                        </div>
-                        <div class="search-field">
-                            <label class="search-label">Lease Duration</label>
-                            <select id="lease" class="search-input">
-                                <option value="6">6 months</option>
-                                <option value="12">12 months</option>
-                                <option value="24">24 months</option>
-                                <option value="flexible">Flexible</option>
-                            </select>
-                        </div>
-                        <div class="search-field">
-                            <label class="search-label">Budget</label>
-                            <select id="budget" class="search-input">
-                                <option value="0-2000">Under $2,000</option>
-                                <option value="2000-3500">$2,000 - $3,500</option>
-                                <option value="3500-5000">$3,500 - $5,000</option>
-                                <option value="5000+">$5,000+</option>
-                            </select>
-                        </div>
-                        <button class="search-btn">Search</button>
-                    </div>
-                    <div class="quick-filters">
-                        <button class="filter-pill active" data-filter="all">All Properties</button>
-                        <button class="filter-pill" data-filter="furnished">Furnished</button>
-                        <button class="filter-pill" data-filter="pets">Pet-Friendly</button>
-                        <button class="filter-pill" data-filter="parking">Parking</button>
-                    </div>
-                </div>
+                <form method="get" action="{% url 'rentals:property_list' %}" class="mb-3">
+                    {{ filter.form|crispy }}
+                    <button type="submit" class="btn btn-primary">Search Properties</button>
+                </form>
             </div>
         </div>
     </section>
@@ -148,6 +63,5 @@
         </div>
     </footer>
 
-    <script src="{% static 'luxury/app.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
The search functionality on the luxury home page (`luxury_home.html`) was previously a standalone HTML/JavaScript implementation. This commit changes it to use the same `django-filter` based backend as the main properties listing page (`property_list.html`).

Changes:
- `LuxuryHomeView` in `rentals/views.py` now inherits from `django_filters.views.FilterView` and is configured to use `PropertyFilter`.
- If filter parameters are present in a GET request to `LuxuryHomeView`, it now redirects to the `property_list` page with those parameters.
- The old HTML/JS search interface in `templates/luxury_home.html` has been removed and replaced with the `django-filter` form (`{{ filter.form|crispy }}`). The form's action is set to the `property_list` URL.
- I've added tests to `rentals/tests/test_views.py` to verify that searching from the luxury home page correctly redirects to the property list page and that the results are filtered as expected.